### PR TITLE
Configure dependabot to only update our gems

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+    - match:
+        dependency_name: "airbrake"
+    - match:
+        dependency_name: "sidekiq"
+    - match:
+        dependency_name: "puma"
+    - match:
+        dependency_name: "foreman"
+    - match:
+        dependency_name: "byebug"


### PR DESCRIPTION
`allowed_updates` should mean that it only updates the gems we've added (docs at https://dependabot.com/docs/config-file/#allowed_updates). I'm unclear what it will do with *their* dependencies, but this is a start.