### PR TITLE
Set-env in Github actions is no longer supported

### DIFF
--- a/.github/workflows/.continuous-integration.yml
+++ b/.github/workflows/.continuous-integration.yml
@@ -7,13 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set Ruby version to use
-      run: |
-        echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ env.RUBY_VERSION }}
     - name: Set up Docker
       run: docker network create test
     - name: Set up Postgres


### PR DESCRIPTION
This action sets the Ruby version automagically.

